### PR TITLE
Prevent crash when getting character before start of line (InsertCharPre error)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: 'actions/checkout@v4'
       - name: 'Setup Vim'
         id: 'vim'
-        uses: 'thinca/action-setup-vim@v1'
+        uses: 'thinca/action-setup-vim@v2'
         with:
           vim_version: '${{ matrix.vim_version || matrix.version }}'
           vim_type: '${{ matrix.vim_type }}'

--- a/autoload/socrates.vim
+++ b/autoload/socrates.vim
@@ -95,6 +95,9 @@ endfunction
 " This function counts both ASCII characters and multibyte characters as a
 " single character.
 function! s:get_exact_nth_char_from(str, n) abort
+  if a:n < 0
+    return ''
+  endif
   return strgetchar(a:str, a:n) ->nr2char()
 endfunction
 
@@ -105,4 +108,3 @@ endfunction
 function! s:is_cursor_at_line_end_in_insert_mode() abort
   return charcol('.') == getline('.') ->strchars() + 1
 endfunction
-

--- a/test/socrates_test.vim
+++ b/test/socrates_test.vim
@@ -65,3 +65,11 @@ function s:suite.get_exact_nth_char_from_string()
   endfor
 endfunction
 
+function s:suite.get_exact_nth_char_from_string_with_negative_values()
+  let sample = 'fooＦＯＯ, barＢＡＲ.'
+
+  call s:assert.equals(
+    \   '', s:funcs.get_exact_nth_char_from(sample, -1)
+    \ )
+endfunction
+


### PR DESCRIPTION
Solution to the issue in [Prevent crash when getting character before start of line (InsertCharPre error)](https://github.com/NI57721/vim-socrates/issues/1)